### PR TITLE
Clean cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -109,6 +109,9 @@ runs:
         set -o igncr # comment to eat potential CR
         CYGWIN_ROOT="$(cygpath -u "${CYGWIN_ROOT}")"
         PACKAGE_CACHE="$(cygpath -u "${PACKAGE_CACHE}")"
+        if [[ "${CYGWIN_ROOT}" == "/" ]]; then
+          CYGWIN_ROOT=""
+        fi
         rm -rf "${PACKAGE_CACHE}/file"*
         awk '$3 == "Extracting" && $4 == "from" { sub(/^file:\/\//, "", $5); gsub(/\//, "\\", $5); print $5 }' "${CYGWIN_ROOT}/var/log/setup.log" | cygpath -uf - | comm --nocheck-order -13 - <(find "${PACKAGE_CACHE}" -type f ! -name setup.ini) | xargs -d '\n' rm -vf
         mv "${PACKAGE_CACHE}" .

--- a/action.yml
+++ b/action.yml
@@ -103,13 +103,20 @@ runs:
         check-hash: ${{ inputs.check-hash }}
         check-installer-sig: ${{ inputs.check-installer-sig }}
         work-vol: ${{ steps.prepare.outputs.vol }}
-    - name: move package cache
+    - name: cleanup package cache
+      # this may be cygwin or git-for-windows bash at this point, so make no assumptions
       run: |
-        if (Test-Path "${{ steps.cygwin-install-action.outputs.package-cache }}\file*" ) {
-          rm -r -fo "${{ steps.cygwin-install-action.outputs.package-cache }}\file*"
-        }
-        move "${{ steps.cygwin-install-action.outputs.package-cache }}" .
-      shell: pwsh
+        set -o igncr # comment to eat potential CR
+        CYGWIN_ROOT="$(cygpath -u "${CYGWIN_ROOT}")"
+        PACKAGE_CACHE="$(cygpath -u "${PACKAGE_CACHE}")"
+        rm -rf "${PACKAGE_CACHE}/file"*
+        awk '$3 == "Extracting" && $4 == "from" { sub(/^file:\/\//, "", $5); gsub(/\//, "\\", $5); print $5 }' "${CYGWIN_ROOT}/var/log/setup.log" | cygpath -uf - | comm --nocheck-order -13 - <(find "${PACKAGE_CACHE}" -type f ! -name setup.ini) | xargs -d '\n' rm -f
+        mv "${PACKAGE_CACHE}" .
+      shell: bash
+      env:
+        CHERE_INVOKING: 1
+        CYGWIN_ROOT: ${{ steps.cygwin-install-action.outputs.root }}
+        PACKAGE_CACHE: ${{ steps.cygwin-install-action.outputs.package-cache }}
     - uses: actions/cache/save@v4
       if: ${{ steps.cache-restore.outputs.cache-matched-key != format('{0}{1}', steps.prepare.outputs.cache-key, hashFiles('cygwin-packages/**', '!cygwin-packages/**/setup.ini')) }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
           CYGWIN_ROOT=""
         fi
         rm -rf "${PACKAGE_CACHE}/file"*
-        awk '$3 == "Extracting" && $4 == "from" { sub(/^file:\/\//, "", $5); gsub(/\//, "\\", $5); print $5 }' "${CYGWIN_ROOT}/var/log/setup.log" | cygpath -uf - | sort |
+        awk '$3 == "Extracting" && $4 == "from" { sub(/^file:\/\//, "", $5); print $5 }' "${CYGWIN_ROOT}/var/log/setup.log" | cygpath -uf - | sort |
           comm -13 - <(find "${PACKAGE_CACHE}" -type f ! -name setup.ini | sort) | xargs -d '\n' rm -vf
         mv "${PACKAGE_CACHE}" .
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,7 @@ runs:
         CYGWIN_ROOT="$(cygpath -u "${CYGWIN_ROOT}")"
         PACKAGE_CACHE="$(cygpath -u "${PACKAGE_CACHE}")"
         rm -rf "${PACKAGE_CACHE}/file"*
-        awk '$3 == "Extracting" && $4 == "from" { sub(/^file:\/\//, "", $5); gsub(/\//, "\\", $5); print $5 }' "${CYGWIN_ROOT}/var/log/setup.log" | cygpath -uf - | comm --nocheck-order -13 - <(find "${PACKAGE_CACHE}" -type f ! -name setup.ini) | xargs -d '\n' rm -f
+        awk '$3 == "Extracting" && $4 == "from" { sub(/^file:\/\//, "", $5); gsub(/\//, "\\", $5); print $5 }' "${CYGWIN_ROOT}/var/log/setup.log" | cygpath -uf - | comm --nocheck-order -13 - <(find "${PACKAGE_CACHE}" -type f ! -name setup.ini) | xargs -d '\n' rm -vf
         mv "${PACKAGE_CACHE}" .
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,8 @@ runs:
           CYGWIN_ROOT=""
         fi
         rm -rf "${PACKAGE_CACHE}/file"*
-        awk '$3 == "Extracting" && $4 == "from" { sub(/^file:\/\//, "", $5); gsub(/\//, "\\", $5); print $5 }' "${CYGWIN_ROOT}/var/log/setup.log" | cygpath -uf - | comm --nocheck-order -13 - <(find "${PACKAGE_CACHE}" -type f ! -name setup.ini) | xargs -d '\n' rm -vf
+        awk '$3 == "Extracting" && $4 == "from" { sub(/^file:\/\//, "", $5); gsub(/\//, "\\", $5); print $5 }' "${CYGWIN_ROOT}/var/log/setup.log" | cygpath -uf - | sort |
+          comm -13 - <(find "${PACKAGE_CACHE}" -type f ! -name setup.ini | sort) | xargs -d '\n' rm -vf
         mv "${PACKAGE_CACHE}" .
       shell: bash
       env:


### PR DESCRIPTION
Use setup.log to find installed files, and remove those from the package-cache which were not installed, assuming that they are no longer needed.